### PR TITLE
Update to self hosted GHA runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ on: [push]
 
 jobs:
   ci:
-    runs-on: ubuntu-latest
+    runs-on: general-purpose
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3

--- a/.github/workflows/test_action.yml
+++ b/.github/workflows/test_action.yml
@@ -2,7 +2,7 @@ on: [push]
 
 jobs:
   test_action:
-    runs-on: ubuntu-latest
+    runs-on: general-purpose
     permissions:
       contents: read
       pull-requests: read


### PR DESCRIPTION
Updating from the GHA cloud runner instance to our own self hosted runners, the cost of cloud runners is ~4x what we spend to self host.

[_Created by Sourcegraph batch change `NoHesHere/update-to-general-purpose`._](https://sourcegraph.build.dox.pub/users/NoHesHere/batch-changes/update-to-general-purpose)