### PR TITLE
Fix pagination for commits and PRs with 100+ changed files

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -20,5 +20,5 @@ outputs:
   callback_return:
     description: 'The return of the callback function'
 runs:
-  using: 'node16'
+  using: 'node24'
   main: 'dist/index.js'

--- a/dist/index.js
+++ b/dist/index.js
@@ -1,7 +1,7 @@
 /******/ (() => { // webpackBootstrap
 /******/ 	var __webpack_modules__ = ({
 
-/***/ 301:
+/***/ 9841:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -27,8 +27,8 @@ var __importStar = (this && this.__importStar) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.issue = exports.issueCommand = void 0;
-const os = __importStar(__nccwpck_require__(2037));
-const utils_1 = __nccwpck_require__(7688);
+const os = __importStar(__nccwpck_require__(857));
+const utils_1 = __nccwpck_require__(8197);
 /**
  * Commands
  *
@@ -100,7 +100,7 @@ function escapeProperty(s) {
 
 /***/ }),
 
-/***/ 4508:
+/***/ 5589:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -135,12 +135,12 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getIDToken = exports.getState = exports.saveState = exports.group = exports.endGroup = exports.startGroup = exports.info = exports.notice = exports.warning = exports.error = exports.debug = exports.isDebug = exports.setFailed = exports.setCommandEcho = exports.setOutput = exports.getBooleanInput = exports.getMultilineInput = exports.getInput = exports.addPath = exports.setSecret = exports.exportVariable = exports.ExitCode = void 0;
-const command_1 = __nccwpck_require__(301);
-const file_command_1 = __nccwpck_require__(51);
-const utils_1 = __nccwpck_require__(7688);
-const os = __importStar(__nccwpck_require__(2037));
-const path = __importStar(__nccwpck_require__(1017));
-const oidc_utils_1 = __nccwpck_require__(2655);
+const command_1 = __nccwpck_require__(9841);
+const file_command_1 = __nccwpck_require__(1804);
+const utils_1 = __nccwpck_require__(8197);
+const os = __importStar(__nccwpck_require__(857));
+const path = __importStar(__nccwpck_require__(6928));
+const oidc_utils_1 = __nccwpck_require__(283);
 /**
  * The code to exit an action
  */
@@ -425,17 +425,17 @@ exports.getIDToken = getIDToken;
 /**
  * Summary exports
  */
-var summary_1 = __nccwpck_require__(8833);
+var summary_1 = __nccwpck_require__(7700);
 Object.defineProperty(exports, "summary", ({ enumerable: true, get: function () { return summary_1.summary; } }));
 /**
  * @deprecated use core.summary
  */
-var summary_2 = __nccwpck_require__(8833);
+var summary_2 = __nccwpck_require__(7700);
 Object.defineProperty(exports, "markdownSummary", ({ enumerable: true, get: function () { return summary_2.markdownSummary; } }));
 /**
  * Path exports
  */
-var path_utils_1 = __nccwpck_require__(1255);
+var path_utils_1 = __nccwpck_require__(1225);
 Object.defineProperty(exports, "toPosixPath", ({ enumerable: true, get: function () { return path_utils_1.toPosixPath; } }));
 Object.defineProperty(exports, "toWin32Path", ({ enumerable: true, get: function () { return path_utils_1.toWin32Path; } }));
 Object.defineProperty(exports, "toPlatformPath", ({ enumerable: true, get: function () { return path_utils_1.toPlatformPath; } }));
@@ -443,7 +443,7 @@ Object.defineProperty(exports, "toPlatformPath", ({ enumerable: true, get: funct
 
 /***/ }),
 
-/***/ 51:
+/***/ 1804:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -472,10 +472,10 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.prepareKeyValueMessage = exports.issueFileCommand = void 0;
 // We use any as a valid input type
 /* eslint-disable @typescript-eslint/no-explicit-any */
-const fs = __importStar(__nccwpck_require__(7147));
-const os = __importStar(__nccwpck_require__(2037));
-const uuid_1 = __nccwpck_require__(2092);
-const utils_1 = __nccwpck_require__(7688);
+const fs = __importStar(__nccwpck_require__(9896));
+const os = __importStar(__nccwpck_require__(857));
+const uuid_1 = __nccwpck_require__(9663);
+const utils_1 = __nccwpck_require__(8197);
 function issueFileCommand(command, message) {
     const filePath = process.env[`GITHUB_${command}`];
     if (!filePath) {
@@ -508,7 +508,7 @@ exports.prepareKeyValueMessage = prepareKeyValueMessage;
 
 /***/ }),
 
-/***/ 2655:
+/***/ 283:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -524,9 +524,9 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.OidcClient = void 0;
-const http_client_1 = __nccwpck_require__(99);
-const auth_1 = __nccwpck_require__(1231);
-const core_1 = __nccwpck_require__(4508);
+const http_client_1 = __nccwpck_require__(6393);
+const auth_1 = __nccwpck_require__(9215);
+const core_1 = __nccwpck_require__(5589);
 class OidcClient {
     static createHttpClient(allowRetry = true, maxRetry = 10) {
         const requestOptions = {
@@ -592,7 +592,7 @@ exports.OidcClient = OidcClient;
 
 /***/ }),
 
-/***/ 1255:
+/***/ 1225:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -618,7 +618,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.toPlatformPath = exports.toWin32Path = exports.toPosixPath = void 0;
-const path = __importStar(__nccwpck_require__(1017));
+const path = __importStar(__nccwpck_require__(6928));
 /**
  * toPosixPath converts the given path to the posix form. On Windows, \\ will be
  * replaced with /.
@@ -657,7 +657,7 @@ exports.toPlatformPath = toPlatformPath;
 
 /***/ }),
 
-/***/ 8833:
+/***/ 7700:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -673,8 +673,8 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.summary = exports.markdownSummary = exports.SUMMARY_DOCS_URL = exports.SUMMARY_ENV_VAR = void 0;
-const os_1 = __nccwpck_require__(2037);
-const fs_1 = __nccwpck_require__(7147);
+const os_1 = __nccwpck_require__(857);
+const fs_1 = __nccwpck_require__(9896);
 const { access, appendFile, writeFile } = fs_1.promises;
 exports.SUMMARY_ENV_VAR = 'GITHUB_STEP_SUMMARY';
 exports.SUMMARY_DOCS_URL = 'https://docs.github.com/actions/using-workflows/workflow-commands-for-github-actions#adding-a-job-summary';
@@ -947,7 +947,7 @@ exports.summary = _summary;
 
 /***/ }),
 
-/***/ 7688:
+/***/ 8197:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -994,7 +994,7 @@ exports.toCommandProperties = toCommandProperties;
 
 /***/ }),
 
-/***/ 1231:
+/***/ 9215:
 /***/ (function(__unused_webpack_module, exports) {
 
 "use strict";
@@ -1082,7 +1082,7 @@ exports.PersonalAccessTokenCredentialHandler = PersonalAccessTokenCredentialHand
 
 /***/ }),
 
-/***/ 99:
+/***/ 6393:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -1118,10 +1118,10 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.HttpClient = exports.isHttps = exports.HttpClientResponse = exports.HttpClientError = exports.getProxyUrl = exports.MediaTypes = exports.Headers = exports.HttpCodes = void 0;
-const http = __importStar(__nccwpck_require__(3685));
-const https = __importStar(__nccwpck_require__(5687));
-const pm = __importStar(__nccwpck_require__(8513));
-const tunnel = __importStar(__nccwpck_require__(6751));
+const http = __importStar(__nccwpck_require__(8611));
+const https = __importStar(__nccwpck_require__(5692));
+const pm = __importStar(__nccwpck_require__(1825));
+const tunnel = __importStar(__nccwpck_require__(8079));
 var HttpCodes;
 (function (HttpCodes) {
     HttpCodes[HttpCodes["OK"] = 200] = "OK";
@@ -1694,7 +1694,7 @@ const lowercaseKeys = (obj) => Object.keys(obj).reduce((c, k) => ((c[k.toLowerCa
 
 /***/ }),
 
-/***/ 8513:
+/***/ 1825:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -1762,34 +1762,34 @@ exports.checkBypass = checkBypass;
 
 /***/ }),
 
-/***/ 8020:
+/***/ 7525:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-module.exports = __nccwpck_require__(1267);
+module.exports = __nccwpck_require__(1803);
 
 /***/ }),
 
-/***/ 3171:
+/***/ 9724:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-var utils = __nccwpck_require__(9887);
-var settle = __nccwpck_require__(8919);
-var buildFullPath = __nccwpck_require__(613);
-var buildURL = __nccwpck_require__(5450);
-var http = __nccwpck_require__(3685);
-var https = __nccwpck_require__(5687);
-var httpFollow = (__nccwpck_require__(5189).http);
-var httpsFollow = (__nccwpck_require__(5189).https);
-var url = __nccwpck_require__(7310);
-var zlib = __nccwpck_require__(9796);
-var VERSION = (__nccwpck_require__(1151).version);
-var createError = __nccwpck_require__(7806);
-var enhanceError = __nccwpck_require__(8801);
-var transitionalDefaults = __nccwpck_require__(7062);
-var Cancel = __nccwpck_require__(6343);
+var utils = __nccwpck_require__(6968);
+var settle = __nccwpck_require__(9670);
+var buildFullPath = __nccwpck_require__(3443);
+var buildURL = __nccwpck_require__(3446);
+var http = __nccwpck_require__(8611);
+var https = __nccwpck_require__(5692);
+var httpFollow = (__nccwpck_require__(3840).http);
+var httpsFollow = (__nccwpck_require__(3840).https);
+var url = __nccwpck_require__(7016);
+var zlib = __nccwpck_require__(3106);
+var VERSION = (__nccwpck_require__(4485).version);
+var createError = __nccwpck_require__(3663);
+var enhanceError = __nccwpck_require__(853);
+var transitionalDefaults = __nccwpck_require__(3180);
+var Cancel = __nccwpck_require__(9396);
 
 var isHttps = /https:?/;
 
@@ -2181,22 +2181,22 @@ module.exports = function httpAdapter(config) {
 
 /***/ }),
 
-/***/ 3310:
+/***/ 1668:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-var utils = __nccwpck_require__(9887);
-var settle = __nccwpck_require__(8919);
-var cookies = __nccwpck_require__(2549);
-var buildURL = __nccwpck_require__(5450);
-var buildFullPath = __nccwpck_require__(613);
-var parseHeaders = __nccwpck_require__(8153);
-var isURLSameOrigin = __nccwpck_require__(4373);
-var createError = __nccwpck_require__(7806);
-var transitionalDefaults = __nccwpck_require__(7062);
-var Cancel = __nccwpck_require__(6343);
+var utils = __nccwpck_require__(6968);
+var settle = __nccwpck_require__(9670);
+var cookies = __nccwpck_require__(5800);
+var buildURL = __nccwpck_require__(3446);
+var buildFullPath = __nccwpck_require__(3443);
+var parseHeaders = __nccwpck_require__(2424);
+var isURLSameOrigin = __nccwpck_require__(502);
+var createError = __nccwpck_require__(3663);
+var transitionalDefaults = __nccwpck_require__(3180);
+var Cancel = __nccwpck_require__(9396);
 
 module.exports = function xhrAdapter(config) {
   return new Promise(function dispatchXhrRequest(resolve, reject) {
@@ -2401,17 +2401,17 @@ module.exports = function xhrAdapter(config) {
 
 /***/ }),
 
-/***/ 1267:
+/***/ 1803:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-var utils = __nccwpck_require__(9887);
-var bind = __nccwpck_require__(7433);
-var Axios = __nccwpck_require__(4435);
-var mergeConfig = __nccwpck_require__(1205);
-var defaults = __nccwpck_require__(7891);
+var utils = __nccwpck_require__(6968);
+var bind = __nccwpck_require__(7632);
+var Axios = __nccwpck_require__(9343);
+var mergeConfig = __nccwpck_require__(7747);
+var defaults = __nccwpck_require__(256);
 
 /**
  * Create an instance of Axios
@@ -2444,19 +2444,19 @@ var axios = createInstance(defaults);
 axios.Axios = Axios;
 
 // Expose Cancel & CancelToken
-axios.Cancel = __nccwpck_require__(6343);
-axios.CancelToken = __nccwpck_require__(6558);
-axios.isCancel = __nccwpck_require__(9990);
-axios.VERSION = (__nccwpck_require__(1151).version);
+axios.Cancel = __nccwpck_require__(9396);
+axios.CancelToken = __nccwpck_require__(2443);
+axios.isCancel = __nccwpck_require__(8052);
+axios.VERSION = (__nccwpck_require__(4485).version);
 
 // Expose all/spread
 axios.all = function all(promises) {
   return Promise.all(promises);
 };
-axios.spread = __nccwpck_require__(7030);
+axios.spread = __nccwpck_require__(4824);
 
 // Expose isAxiosError
-axios.isAxiosError = __nccwpck_require__(6257);
+axios.isAxiosError = __nccwpck_require__(9583);
 
 module.exports = axios;
 
@@ -2466,7 +2466,7 @@ module.exports["default"] = axios;
 
 /***/ }),
 
-/***/ 6343:
+/***/ 9396:
 /***/ ((module) => {
 
 "use strict";
@@ -2493,13 +2493,13 @@ module.exports = Cancel;
 
 /***/ }),
 
-/***/ 6558:
+/***/ 2443:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-var Cancel = __nccwpck_require__(6343);
+var Cancel = __nccwpck_require__(9396);
 
 /**
  * A `CancelToken` is an object that can be used to request cancellation of an operation.
@@ -2620,7 +2620,7 @@ module.exports = CancelToken;
 
 /***/ }),
 
-/***/ 9990:
+/***/ 8052:
 /***/ ((module) => {
 
 "use strict";
@@ -2633,18 +2633,18 @@ module.exports = function isCancel(value) {
 
 /***/ }),
 
-/***/ 4435:
+/***/ 9343:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-var utils = __nccwpck_require__(9887);
-var buildURL = __nccwpck_require__(5450);
-var InterceptorManager = __nccwpck_require__(9725);
-var dispatchRequest = __nccwpck_require__(7545);
-var mergeConfig = __nccwpck_require__(1205);
-var validator = __nccwpck_require__(9746);
+var utils = __nccwpck_require__(6968);
+var buildURL = __nccwpck_require__(3446);
+var InterceptorManager = __nccwpck_require__(4875);
+var dispatchRequest = __nccwpck_require__(3726);
+var mergeConfig = __nccwpck_require__(7747);
+var validator = __nccwpck_require__(7717);
 
 var validators = validator.validators;
 /**
@@ -2789,13 +2789,13 @@ module.exports = Axios;
 
 /***/ }),
 
-/***/ 9725:
+/***/ 4875:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-var utils = __nccwpck_require__(9887);
+var utils = __nccwpck_require__(6968);
 
 function InterceptorManager() {
   this.handlers = [];
@@ -2851,14 +2851,14 @@ module.exports = InterceptorManager;
 
 /***/ }),
 
-/***/ 613:
+/***/ 3443:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-var isAbsoluteURL = __nccwpck_require__(9579);
-var combineURLs = __nccwpck_require__(5996);
+var isAbsoluteURL = __nccwpck_require__(3053);
+var combineURLs = __nccwpck_require__(8140);
 
 /**
  * Creates a new URL by combining the baseURL with the requestedURL,
@@ -2879,13 +2879,13 @@ module.exports = function buildFullPath(baseURL, requestedURL) {
 
 /***/ }),
 
-/***/ 7806:
+/***/ 3663:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-var enhanceError = __nccwpck_require__(8801);
+var enhanceError = __nccwpck_require__(853);
 
 /**
  * Create an Error with the specified message, config, error code, request and response.
@@ -2905,17 +2905,17 @@ module.exports = function createError(message, config, code, request, response) 
 
 /***/ }),
 
-/***/ 7545:
+/***/ 3726:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-var utils = __nccwpck_require__(9887);
-var transformData = __nccwpck_require__(8452);
-var isCancel = __nccwpck_require__(9990);
-var defaults = __nccwpck_require__(7891);
-var Cancel = __nccwpck_require__(6343);
+var utils = __nccwpck_require__(6968);
+var transformData = __nccwpck_require__(9277);
+var isCancel = __nccwpck_require__(8052);
+var defaults = __nccwpck_require__(256);
+var Cancel = __nccwpck_require__(9396);
 
 /**
  * Throws a `Cancel` if cancellation has been requested.
@@ -3000,7 +3000,7 @@ module.exports = function dispatchRequest(config) {
 
 /***/ }),
 
-/***/ 8801:
+/***/ 853:
 /***/ ((module) => {
 
 "use strict";
@@ -3051,13 +3051,13 @@ module.exports = function enhanceError(error, config, code, request, response) {
 
 /***/ }),
 
-/***/ 1205:
+/***/ 7747:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-var utils = __nccwpck_require__(9887);
+var utils = __nccwpck_require__(6968);
 
 /**
  * Config-specific merge-function which creates a new config-object
@@ -3158,13 +3158,13 @@ module.exports = function mergeConfig(config1, config2) {
 
 /***/ }),
 
-/***/ 8919:
+/***/ 9670:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-var createError = __nccwpck_require__(7806);
+var createError = __nccwpck_require__(3663);
 
 /**
  * Resolve or reject a Promise based on response status.
@@ -3191,14 +3191,14 @@ module.exports = function settle(resolve, reject, response) {
 
 /***/ }),
 
-/***/ 8452:
+/***/ 9277:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-var utils = __nccwpck_require__(9887);
-var defaults = __nccwpck_require__(7891);
+var utils = __nccwpck_require__(6968);
+var defaults = __nccwpck_require__(256);
 
 /**
  * Transform the data for a request or a response
@@ -3221,16 +3221,16 @@ module.exports = function transformData(data, headers, fns) {
 
 /***/ }),
 
-/***/ 7891:
+/***/ 256:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-var utils = __nccwpck_require__(9887);
-var normalizeHeaderName = __nccwpck_require__(8602);
-var enhanceError = __nccwpck_require__(8801);
-var transitionalDefaults = __nccwpck_require__(7062);
+var utils = __nccwpck_require__(6968);
+var normalizeHeaderName = __nccwpck_require__(2134);
+var enhanceError = __nccwpck_require__(853);
+var transitionalDefaults = __nccwpck_require__(3180);
 
 var DEFAULT_CONTENT_TYPE = {
   'Content-Type': 'application/x-www-form-urlencoded'
@@ -3246,10 +3246,10 @@ function getDefaultAdapter() {
   var adapter;
   if (typeof XMLHttpRequest !== 'undefined') {
     // For browsers use XHR adapter
-    adapter = __nccwpck_require__(3310);
+    adapter = __nccwpck_require__(1668);
   } else if (typeof process !== 'undefined' && Object.prototype.toString.call(process) === '[object process]') {
     // For node use HTTP adapter
-    adapter = __nccwpck_require__(3171);
+    adapter = __nccwpck_require__(9724);
   }
   return adapter;
 }
@@ -3360,7 +3360,7 @@ module.exports = defaults;
 
 /***/ }),
 
-/***/ 7062:
+/***/ 3180:
 /***/ ((module) => {
 
 "use strict";
@@ -3375,7 +3375,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 1151:
+/***/ 4485:
 /***/ ((module) => {
 
 module.exports = {
@@ -3384,7 +3384,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 7433:
+/***/ 7632:
 /***/ ((module) => {
 
 "use strict";
@@ -3403,13 +3403,13 @@ module.exports = function bind(fn, thisArg) {
 
 /***/ }),
 
-/***/ 5450:
+/***/ 3446:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-var utils = __nccwpck_require__(9887);
+var utils = __nccwpck_require__(6968);
 
 function encode(val) {
   return encodeURIComponent(val).
@@ -3481,7 +3481,7 @@ module.exports = function buildURL(url, params, paramsSerializer) {
 
 /***/ }),
 
-/***/ 5996:
+/***/ 8140:
 /***/ ((module) => {
 
 "use strict";
@@ -3503,13 +3503,13 @@ module.exports = function combineURLs(baseURL, relativeURL) {
 
 /***/ }),
 
-/***/ 2549:
+/***/ 5800:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-var utils = __nccwpck_require__(9887);
+var utils = __nccwpck_require__(6968);
 
 module.exports = (
   utils.isStandardBrowserEnv() ?
@@ -3564,7 +3564,7 @@ module.exports = (
 
 /***/ }),
 
-/***/ 9579:
+/***/ 3053:
 /***/ ((module) => {
 
 "use strict";
@@ -3586,13 +3586,13 @@ module.exports = function isAbsoluteURL(url) {
 
 /***/ }),
 
-/***/ 6257:
+/***/ 9583:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-var utils = __nccwpck_require__(9887);
+var utils = __nccwpck_require__(6968);
 
 /**
  * Determines whether the payload is an error thrown by Axios
@@ -3607,13 +3607,13 @@ module.exports = function isAxiosError(payload) {
 
 /***/ }),
 
-/***/ 4373:
+/***/ 502:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-var utils = __nccwpck_require__(9887);
+var utils = __nccwpck_require__(6968);
 
 module.exports = (
   utils.isStandardBrowserEnv() ?
@@ -3683,13 +3683,13 @@ module.exports = (
 
 /***/ }),
 
-/***/ 8602:
+/***/ 2134:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-var utils = __nccwpck_require__(9887);
+var utils = __nccwpck_require__(6968);
 
 module.exports = function normalizeHeaderName(headers, normalizedName) {
   utils.forEach(headers, function processHeader(value, name) {
@@ -3703,13 +3703,13 @@ module.exports = function normalizeHeaderName(headers, normalizedName) {
 
 /***/ }),
 
-/***/ 8153:
+/***/ 2424:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-var utils = __nccwpck_require__(9887);
+var utils = __nccwpck_require__(6968);
 
 // Headers whose duplicates are ignored by node
 // c.f. https://nodejs.org/api/http.html#http_message_headers
@@ -3764,7 +3764,7 @@ module.exports = function parseHeaders(headers) {
 
 /***/ }),
 
-/***/ 7030:
+/***/ 4824:
 /***/ ((module) => {
 
 "use strict";
@@ -3799,13 +3799,13 @@ module.exports = function spread(callback) {
 
 /***/ }),
 
-/***/ 9746:
+/***/ 7717:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-var VERSION = (__nccwpck_require__(1151).version);
+var VERSION = (__nccwpck_require__(4485).version);
 
 var validators = {};
 
@@ -3889,13 +3889,13 @@ module.exports = {
 
 /***/ }),
 
-/***/ 9887:
+/***/ 6968:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-var bind = __nccwpck_require__(7433);
+var bind = __nccwpck_require__(7632);
 
 // utils is a library of generic helper functions non-specific to axios
 
@@ -4246,7 +4246,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 8574:
+/***/ 8479:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var debug;
@@ -4255,7 +4255,7 @@ module.exports = function () {
   if (!debug) {
     try {
       /* eslint global-require: off */
-      debug = __nccwpck_require__(7206)("follow-redirects");
+      debug = __nccwpck_require__(4401)("follow-redirects");
     }
     catch (error) { /* */ }
     if (typeof debug !== "function") {
@@ -4268,16 +4268,16 @@ module.exports = function () {
 
 /***/ }),
 
-/***/ 5189:
+/***/ 3840:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var url = __nccwpck_require__(7310);
+var url = __nccwpck_require__(7016);
 var URL = url.URL;
-var http = __nccwpck_require__(3685);
-var https = __nccwpck_require__(5687);
-var Writable = (__nccwpck_require__(2781).Writable);
-var assert = __nccwpck_require__(9491);
-var debug = __nccwpck_require__(8574);
+var http = __nccwpck_require__(8611);
+var https = __nccwpck_require__(5692);
+var Writable = (__nccwpck_require__(2203).Writable);
+var assert = __nccwpck_require__(2613);
+var debug = __nccwpck_require__(8479);
 
 // Create handlers that pass events from native requests
 var events = ["abort", "aborted", "connect", "error", "socket", "timeout"];
@@ -4849,27 +4849,27 @@ module.exports.wrap = wrap;
 
 /***/ }),
 
-/***/ 6751:
+/***/ 8079:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-module.exports = __nccwpck_require__(7492);
+module.exports = __nccwpck_require__(6057);
 
 
 /***/ }),
 
-/***/ 7492:
+/***/ 6057:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-var net = __nccwpck_require__(1808);
-var tls = __nccwpck_require__(4404);
-var http = __nccwpck_require__(3685);
-var https = __nccwpck_require__(5687);
-var events = __nccwpck_require__(2361);
-var assert = __nccwpck_require__(9491);
-var util = __nccwpck_require__(3837);
+var net = __nccwpck_require__(9278);
+var tls = __nccwpck_require__(4756);
+var http = __nccwpck_require__(8611);
+var https = __nccwpck_require__(5692);
+var events = __nccwpck_require__(4434);
+var assert = __nccwpck_require__(2613);
+var util = __nccwpck_require__(9023);
 
 
 exports.httpOverHttp = httpOverHttp;
@@ -5129,7 +5129,7 @@ exports.debug = debug; // for test
 
 /***/ }),
 
-/***/ 2092:
+/***/ 9663:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -5193,29 +5193,29 @@ Object.defineProperty(exports, "parse", ({
   }
 }));
 
-var _v = _interopRequireDefault(__nccwpck_require__(9381));
+var _v = _interopRequireDefault(__nccwpck_require__(3950));
 
-var _v2 = _interopRequireDefault(__nccwpck_require__(6911));
+var _v2 = _interopRequireDefault(__nccwpck_require__(9492));
 
-var _v3 = _interopRequireDefault(__nccwpck_require__(1717));
+var _v3 = _interopRequireDefault(__nccwpck_require__(7089));
 
-var _v4 = _interopRequireDefault(__nccwpck_require__(6933));
+var _v4 = _interopRequireDefault(__nccwpck_require__(6162));
 
-var _nil = _interopRequireDefault(__nccwpck_require__(8226));
+var _nil = _interopRequireDefault(__nccwpck_require__(9048));
 
-var _version = _interopRequireDefault(__nccwpck_require__(3994));
+var _version = _interopRequireDefault(__nccwpck_require__(9103));
 
-var _validate = _interopRequireDefault(__nccwpck_require__(3316));
+var _validate = _interopRequireDefault(__nccwpck_require__(7389));
 
-var _stringify = _interopRequireDefault(__nccwpck_require__(6361));
+var _stringify = _interopRequireDefault(__nccwpck_require__(8966));
 
-var _parse = _interopRequireDefault(__nccwpck_require__(8533));
+var _parse = _interopRequireDefault(__nccwpck_require__(88));
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 /***/ }),
 
-/***/ 1667:
+/***/ 151:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -5226,7 +5226,7 @@ Object.defineProperty(exports, "__esModule", ({
 }));
 exports["default"] = void 0;
 
-var _crypto = _interopRequireDefault(__nccwpck_require__(6113));
+var _crypto = _interopRequireDefault(__nccwpck_require__(6982));
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -5245,7 +5245,7 @@ exports["default"] = _default;
 
 /***/ }),
 
-/***/ 8226:
+/***/ 9048:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -5260,7 +5260,7 @@ exports["default"] = _default;
 
 /***/ }),
 
-/***/ 8533:
+/***/ 88:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -5271,7 +5271,7 @@ Object.defineProperty(exports, "__esModule", ({
 }));
 exports["default"] = void 0;
 
-var _validate = _interopRequireDefault(__nccwpck_require__(3316));
+var _validate = _interopRequireDefault(__nccwpck_require__(7389));
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -5312,7 +5312,7 @@ exports["default"] = _default;
 
 /***/ }),
 
-/***/ 4042:
+/***/ 5144:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -5327,7 +5327,7 @@ exports["default"] = _default;
 
 /***/ }),
 
-/***/ 2635:
+/***/ 3610:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -5338,7 +5338,7 @@ Object.defineProperty(exports, "__esModule", ({
 }));
 exports["default"] = rng;
 
-var _crypto = _interopRequireDefault(__nccwpck_require__(6113));
+var _crypto = _interopRequireDefault(__nccwpck_require__(6982));
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -5358,7 +5358,7 @@ function rng() {
 
 /***/ }),
 
-/***/ 5251:
+/***/ 4258:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -5369,7 +5369,7 @@ Object.defineProperty(exports, "__esModule", ({
 }));
 exports["default"] = void 0;
 
-var _crypto = _interopRequireDefault(__nccwpck_require__(6113));
+var _crypto = _interopRequireDefault(__nccwpck_require__(6982));
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -5388,7 +5388,7 @@ exports["default"] = _default;
 
 /***/ }),
 
-/***/ 6361:
+/***/ 8966:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -5399,7 +5399,7 @@ Object.defineProperty(exports, "__esModule", ({
 }));
 exports["default"] = void 0;
 
-var _validate = _interopRequireDefault(__nccwpck_require__(3316));
+var _validate = _interopRequireDefault(__nccwpck_require__(7389));
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -5434,7 +5434,7 @@ exports["default"] = _default;
 
 /***/ }),
 
-/***/ 9381:
+/***/ 3950:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -5445,9 +5445,9 @@ Object.defineProperty(exports, "__esModule", ({
 }));
 exports["default"] = void 0;
 
-var _rng = _interopRequireDefault(__nccwpck_require__(2635));
+var _rng = _interopRequireDefault(__nccwpck_require__(3610));
 
-var _stringify = _interopRequireDefault(__nccwpck_require__(6361));
+var _stringify = _interopRequireDefault(__nccwpck_require__(8966));
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -5548,7 +5548,7 @@ exports["default"] = _default;
 
 /***/ }),
 
-/***/ 6911:
+/***/ 9492:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -5559,9 +5559,9 @@ Object.defineProperty(exports, "__esModule", ({
 }));
 exports["default"] = void 0;
 
-var _v = _interopRequireDefault(__nccwpck_require__(2726));
+var _v = _interopRequireDefault(__nccwpck_require__(2001));
 
-var _md = _interopRequireDefault(__nccwpck_require__(1667));
+var _md = _interopRequireDefault(__nccwpck_require__(151));
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -5571,7 +5571,7 @@ exports["default"] = _default;
 
 /***/ }),
 
-/***/ 2726:
+/***/ 2001:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -5583,9 +5583,9 @@ Object.defineProperty(exports, "__esModule", ({
 exports["default"] = _default;
 exports.URL = exports.DNS = void 0;
 
-var _stringify = _interopRequireDefault(__nccwpck_require__(6361));
+var _stringify = _interopRequireDefault(__nccwpck_require__(8966));
 
-var _parse = _interopRequireDefault(__nccwpck_require__(8533));
+var _parse = _interopRequireDefault(__nccwpck_require__(88));
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -5656,7 +5656,7 @@ function _default(name, version, hashfunc) {
 
 /***/ }),
 
-/***/ 1717:
+/***/ 7089:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -5667,9 +5667,9 @@ Object.defineProperty(exports, "__esModule", ({
 }));
 exports["default"] = void 0;
 
-var _rng = _interopRequireDefault(__nccwpck_require__(2635));
+var _rng = _interopRequireDefault(__nccwpck_require__(3610));
 
-var _stringify = _interopRequireDefault(__nccwpck_require__(6361));
+var _stringify = _interopRequireDefault(__nccwpck_require__(8966));
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -5700,7 +5700,7 @@ exports["default"] = _default;
 
 /***/ }),
 
-/***/ 6933:
+/***/ 6162:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -5711,9 +5711,9 @@ Object.defineProperty(exports, "__esModule", ({
 }));
 exports["default"] = void 0;
 
-var _v = _interopRequireDefault(__nccwpck_require__(2726));
+var _v = _interopRequireDefault(__nccwpck_require__(2001));
 
-var _sha = _interopRequireDefault(__nccwpck_require__(5251));
+var _sha = _interopRequireDefault(__nccwpck_require__(4258));
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -5723,7 +5723,7 @@ exports["default"] = _default;
 
 /***/ }),
 
-/***/ 3316:
+/***/ 7389:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -5734,7 +5734,7 @@ Object.defineProperty(exports, "__esModule", ({
 }));
 exports["default"] = void 0;
 
-var _regex = _interopRequireDefault(__nccwpck_require__(4042));
+var _regex = _interopRequireDefault(__nccwpck_require__(5144));
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -5747,7 +5747,7 @@ exports["default"] = _default;
 
 /***/ }),
 
-/***/ 3994:
+/***/ 9103:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -5758,7 +5758,7 @@ Object.defineProperty(exports, "__esModule", ({
 }));
 exports["default"] = void 0;
 
-var _validate = _interopRequireDefault(__nccwpck_require__(3316));
+var _validate = _interopRequireDefault(__nccwpck_require__(7389));
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -5775,10 +5775,10 @@ exports["default"] = _default;
 
 /***/ }),
 
-/***/ 4928:
+/***/ 6542:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-const axios = __nccwpck_require__(8020);
+const axios = __nccwpck_require__(7525);
 
 class GithubApiClient {
   constructor(token) {
@@ -5792,6 +5792,27 @@ class GithubApiClient {
     const result = await this.client.get(path);
     return result.data;
   }
+
+  async getPaginated(path) {
+    const pages = [];
+    let nextPath = path;
+
+    while (nextPath) {
+      // eslint-disable-next-line no-await-in-loop
+      const result = await this.client.get(nextPath);
+      pages.push(result.data);
+
+      const linkHeader = result.headers.link;
+      if (linkHeader) {
+        const nextMatch = linkHeader.match(/<([^>]+)>;\s*rel="next"/);
+        nextPath = nextMatch ? nextMatch[1] : null;
+      } else {
+        nextPath = null;
+      }
+    }
+
+    return pages;
+  }
 }
 
 module.exports = GithubApiClient;
@@ -5799,11 +5820,11 @@ module.exports = GithubApiClient;
 
 /***/ }),
 
-/***/ 278:
+/***/ 1443:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-const PullRequestStrategy = __nccwpck_require__(5352);
-const RefStrategy = __nccwpck_require__(4558);
+const PullRequestStrategy = __nccwpck_require__(2459);
+const RefStrategy = __nccwpck_require__(3765);
 
 function validateInputs(inputs) {
   if (inputs.ref && inputs.prNumber) {
@@ -5835,10 +5856,10 @@ module.exports = {
 
 /***/ }),
 
-/***/ 4425:
+/***/ 4423:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-const GithubApiClient = __nccwpck_require__(4928);
+const GithubApiClient = __nccwpck_require__(6542);
 
 class BaseStrategy {
   constructor({
@@ -5870,18 +5891,18 @@ module.exports = BaseStrategy;
 
 /***/ }),
 
-/***/ 5352:
+/***/ 2459:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-const BaseStrategy = __nccwpck_require__(4425);
+const BaseStrategy = __nccwpck_require__(4423);
 
 class PullRequestStrategy extends BaseStrategy {
-  filterPayload(payload) {
-    return payload.map((item) => item.filename);
+  filterPayload(pages) {
+    return pages.flat().map((item) => item.filename);
   }
 
   async fetchPayload() {
-    return this.httpClient.get(`/repos/${this.repository}/pulls/${this.prNumber}/files?per_page=100`);
+    return this.httpClient.getPaginated(`/repos/${this.repository}/pulls/${this.prNumber}/files?per_page=100`);
   }
 }
 
@@ -5890,18 +5911,19 @@ module.exports = PullRequestStrategy;
 
 /***/ }),
 
-/***/ 4558:
+/***/ 3765:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-const BaseStrategy = __nccwpck_require__(4425);
+const BaseStrategy = __nccwpck_require__(4423);
 
 class RefStrategy extends BaseStrategy {
-  filterPayload(payload) {
-    return payload.files.map((fileMetadata) => fileMetadata.filename);
+  filterPayload(pages) {
+    const files = pages.flatMap((page) => page.files);
+    return files.map((fileMetadata) => fileMetadata.filename);
   }
 
   async fetchPayload() {
-    return this.httpClient.get(`/repos/${this.repository}/commits/${this.ref}?per_page=100`);
+    return this.httpClient.getPaginated(`/repos/${this.repository}/commits/${this.ref}?per_page=100`);
   }
 }
 
@@ -5910,7 +5932,7 @@ module.exports = RefStrategy;
 
 /***/ }),
 
-/***/ 7206:
+/***/ 4401:
 /***/ ((module) => {
 
 module.exports = eval("require")("debug");
@@ -5918,7 +5940,7 @@ module.exports = eval("require")("debug");
 
 /***/ }),
 
-/***/ 9491:
+/***/ 2613:
 /***/ ((module) => {
 
 "use strict";
@@ -5926,7 +5948,7 @@ module.exports = require("assert");
 
 /***/ }),
 
-/***/ 6113:
+/***/ 6982:
 /***/ ((module) => {
 
 "use strict";
@@ -5934,7 +5956,7 @@ module.exports = require("crypto");
 
 /***/ }),
 
-/***/ 2361:
+/***/ 4434:
 /***/ ((module) => {
 
 "use strict";
@@ -5942,7 +5964,7 @@ module.exports = require("events");
 
 /***/ }),
 
-/***/ 7147:
+/***/ 9896:
 /***/ ((module) => {
 
 "use strict";
@@ -5950,7 +5972,7 @@ module.exports = require("fs");
 
 /***/ }),
 
-/***/ 3685:
+/***/ 8611:
 /***/ ((module) => {
 
 "use strict";
@@ -5958,7 +5980,7 @@ module.exports = require("http");
 
 /***/ }),
 
-/***/ 5687:
+/***/ 5692:
 /***/ ((module) => {
 
 "use strict";
@@ -5966,7 +5988,7 @@ module.exports = require("https");
 
 /***/ }),
 
-/***/ 1808:
+/***/ 9278:
 /***/ ((module) => {
 
 "use strict";
@@ -5974,7 +5996,7 @@ module.exports = require("net");
 
 /***/ }),
 
-/***/ 2037:
+/***/ 857:
 /***/ ((module) => {
 
 "use strict";
@@ -5982,7 +6004,7 @@ module.exports = require("os");
 
 /***/ }),
 
-/***/ 1017:
+/***/ 6928:
 /***/ ((module) => {
 
 "use strict";
@@ -5990,7 +6012,7 @@ module.exports = require("path");
 
 /***/ }),
 
-/***/ 2781:
+/***/ 2203:
 /***/ ((module) => {
 
 "use strict";
@@ -5998,7 +6020,7 @@ module.exports = require("stream");
 
 /***/ }),
 
-/***/ 4404:
+/***/ 4756:
 /***/ ((module) => {
 
 "use strict";
@@ -6006,7 +6028,7 @@ module.exports = require("tls");
 
 /***/ }),
 
-/***/ 7310:
+/***/ 7016:
 /***/ ((module) => {
 
 "use strict";
@@ -6014,7 +6036,7 @@ module.exports = require("url");
 
 /***/ }),
 
-/***/ 3837:
+/***/ 9023:
 /***/ ((module) => {
 
 "use strict";
@@ -6022,7 +6044,7 @@ module.exports = require("util");
 
 /***/ }),
 
-/***/ 9796:
+/***/ 3106:
 /***/ ((module) => {
 
 "use strict";
@@ -6069,10 +6091,8 @@ module.exports = require("zlib");
 /******/ 	
 /************************************************************************/
 var __webpack_exports__ = {};
-// This entry need to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
-(() => {
-const core = __nccwpck_require__(4508);
-const { listFilenames } = __nccwpck_require__(278);
+const core = __nccwpck_require__(5589);
+const { listFilenames } = __nccwpck_require__(1443);
 
 async function main() {
   try {
@@ -6095,8 +6115,6 @@ async function main() {
 }
 
 main();
-
-})();
 
 module.exports = __webpack_exports__;
 /******/ })()

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gh-action-callback-list-files",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Github action for running a callback after pulling a list of filenames",
   "main": "src/index.js",
   "repository": "git@github.com:doximity/gh-action-callback-list-files.git",

--- a/src/github_api_client.js
+++ b/src/github_api_client.js
@@ -12,6 +12,27 @@ class GithubApiClient {
     const result = await this.client.get(path);
     return result.data;
   }
+
+  async getPaginated(path) {
+    const pages = [];
+    let nextPath = path;
+
+    while (nextPath) {
+      // eslint-disable-next-line no-await-in-loop
+      const result = await this.client.get(nextPath);
+      pages.push(result.data);
+
+      const linkHeader = result.headers.link;
+      if (linkHeader) {
+        const nextMatch = linkHeader.match(/<([^>]+)>;\s*rel="next"/);
+        nextPath = nextMatch ? nextMatch[1] : null;
+      } else {
+        nextPath = null;
+      }
+    }
+
+    return pages;
+  }
 }
 
 module.exports = GithubApiClient;

--- a/src/strategies/pull_request.js
+++ b/src/strategies/pull_request.js
@@ -1,12 +1,12 @@
 const BaseStrategy = require('./base');
 
 class PullRequestStrategy extends BaseStrategy {
-  filterPayload(payload) {
-    return payload.map((item) => item.filename);
+  filterPayload(pages) {
+    return pages.flat().map((item) => item.filename);
   }
 
   async fetchPayload() {
-    return this.httpClient.get(`/repos/${this.repository}/pulls/${this.prNumber}/files?per_page=100`);
+    return this.httpClient.getPaginated(`/repos/${this.repository}/pulls/${this.prNumber}/files?per_page=100`);
   }
 }
 

--- a/src/strategies/ref.js
+++ b/src/strategies/ref.js
@@ -1,12 +1,13 @@
 const BaseStrategy = require('./base');
 
 class RefStrategy extends BaseStrategy {
-  filterPayload(payload) {
-    return payload.files.map((fileMetadata) => fileMetadata.filename);
+  filterPayload(pages) {
+    const files = pages.flatMap((page) => page.files);
+    return files.map((fileMetadata) => fileMetadata.filename);
   }
 
   async fetchPayload() {
-    return this.httpClient.get(`/repos/${this.repository}/commits/${this.ref}?per_page=100`);
+    return this.httpClient.getPaginated(`/repos/${this.repository}/commits/${this.ref}?per_page=100`);
   }
 }
 

--- a/test/unit/github_api_client.test.js
+++ b/test/unit/github_api_client.test.js
@@ -1,0 +1,74 @@
+const GithubApiClient = require('../../src/github_api_client');
+
+jest.mock('axios', () => ({
+  create: jest.fn(() => {
+    const mockAxios = jest.fn();
+    mockAxios.get = jest.fn();
+    return { get: mockAxios.get };
+  }),
+}));
+
+describe('GithubApiClient', () => {
+  let client;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    client = new GithubApiClient('fake-token');
+  });
+
+  describe('get', () => {
+    test('returns response data', async () => {
+      client.client.get.mockResolvedValue({ data: { foo: 'bar' } });
+      const result = await client.get('/some/path');
+      expect(result).toEqual({ foo: 'bar' });
+    });
+  });
+
+  describe('getPaginated', () => {
+    test('returns all pages when Link header has next', async () => {
+      client.client.get
+        .mockResolvedValueOnce({
+          data: [{ filename: 'a.js' }],
+          headers: { link: '<https://api.github.com/page2>; rel="next"' },
+        })
+        .mockResolvedValueOnce({
+          data: [{ filename: 'b.js' }],
+          headers: { link: '<https://api.github.com/page3>; rel="next"' },
+        })
+        .mockResolvedValueOnce({
+          data: [{ filename: 'c.js' }],
+          headers: {},
+        });
+
+      const result = await client.getPaginated('/repos/doximity/doximity/commits/abc?per_page=100');
+      expect(result).toEqual([
+        [{ filename: 'a.js' }],
+        [{ filename: 'b.js' }],
+        [{ filename: 'c.js' }],
+      ]);
+      expect(client.client.get).toHaveBeenCalledTimes(3);
+    });
+
+    test('returns single page when no Link header', async () => {
+      client.client.get.mockResolvedValue({
+        data: { files: [{ filename: 'a.js' }] },
+        headers: {},
+      });
+
+      const result = await client.getPaginated('/repos/doximity/doximity/commits/abc?per_page=100');
+      expect(result).toEqual([{ files: [{ filename: 'a.js' }] }]);
+      expect(client.client.get).toHaveBeenCalledTimes(1);
+    });
+
+    test('returns single page when Link header has no next', async () => {
+      client.client.get.mockResolvedValue({
+        data: [{ filename: 'a.js' }],
+        headers: { link: '<https://api.github.com/page1>; rel="prev"' },
+      });
+
+      const result = await client.getPaginated('/some/path');
+      expect(result).toEqual([[{ filename: 'a.js' }]]);
+      expect(client.client.get).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/test/unit/pull_request_strategy.test.js
+++ b/test/unit/pull_request_strategy.test.js
@@ -1,0 +1,46 @@
+const PullRequestStrategy = require('../../src/strategies/pull_request');
+const GithubApiClient = require('../../src/github_api_client');
+
+jest.mock('../../src/github_api_client');
+
+describe('PullRequestStrategy', () => {
+  const inputs = {
+    repository: 'doximity/doximity',
+    prNumber: '123',
+    token: 'fake-token',
+  };
+
+  test('returns filenames from a single page', async () => {
+    const mockClient = {
+      getPaginated: jest.fn().mockResolvedValue([
+        [{ filename: 'file1.js' }, { filename: 'file2.js' }],
+      ]),
+    };
+    GithubApiClient.mockImplementation(() => mockClient);
+
+    const strategy = new PullRequestStrategy(inputs);
+    const result = await strategy.filenames();
+
+    expect(result).toEqual(['file1.js', 'file2.js']);
+    expect(mockClient.getPaginated).toHaveBeenCalledWith(
+      '/repos/doximity/doximity/pulls/123/files?per_page=100',
+    );
+  });
+
+  test('merges filenames across multiple pages', async () => {
+    const page1 = Array.from({ length: 100 }, (_, i) => ({ filename: `file${i}.js` }));
+    const page2 = [{ filename: 'file100.js' }, { filename: 'file101.js' }];
+
+    const mockClient = {
+      getPaginated: jest.fn().mockResolvedValue([page1, page2]),
+    };
+    GithubApiClient.mockImplementation(() => mockClient);
+
+    const strategy = new PullRequestStrategy(inputs);
+    const result = await strategy.filenames();
+
+    expect(result).toHaveLength(102);
+    expect(result).toContain('file0.js');
+    expect(result).toContain('file101.js');
+  });
+});

--- a/test/unit/ref_strategy.test.js
+++ b/test/unit/ref_strategy.test.js
@@ -1,0 +1,54 @@
+const RefStrategy = require('../../src/strategies/ref');
+const GithubApiClient = require('../../src/github_api_client');
+
+jest.mock('../../src/github_api_client');
+
+describe('RefStrategy', () => {
+  const inputs = {
+    repository: 'doximity/doximity',
+    ref: 'abc123',
+    token: 'fake-token',
+  };
+
+  test('returns filenames from a single page', async () => {
+    const mockClient = {
+      getPaginated: jest.fn().mockResolvedValue([
+        { files: [{ filename: 'file1.js' }, { filename: 'file2.js' }] },
+      ]),
+    };
+    GithubApiClient.mockImplementation(() => mockClient);
+
+    const strategy = new RefStrategy(inputs);
+    const result = await strategy.filenames();
+
+    expect(result).toEqual(['file1.js', 'file2.js']);
+    expect(mockClient.getPaginated).toHaveBeenCalledWith(
+      '/repos/doximity/doximity/commits/abc123?per_page=100',
+    );
+  });
+
+  test('merges filenames across multiple pages', async () => {
+    const page1 = Array.from({ length: 100 }, (_, i) => ({ filename: `file${i}.js` }));
+    const page2 = [
+      { filename: 'file100.js' },
+      { filename: 'file101.js' },
+      { filename: 'config/graphql/federation_subgraph_schema.gql' },
+    ];
+
+    const mockClient = {
+      getPaginated: jest.fn().mockResolvedValue([
+        { files: page1 },
+        { files: page2 },
+      ]),
+    };
+    GithubApiClient.mockImplementation(() => mockClient);
+
+    const strategy = new RefStrategy(inputs);
+    const result = await strategy.filenames();
+
+    expect(result).toHaveLength(103);
+    expect(result).toContain('config/graphql/federation_subgraph_schema.gql');
+    expect(result).toContain('file0.js');
+    expect(result).toContain('file101.js');
+  });
+});


### PR DESCRIPTION
[CSVUEAN-3043](https://doximity.atlassian.net/browse/CSVUEAN-3043)

## Problem

The `ref` and `pull_request` strategies both fetched only the first 100 files from the GitHub API without following `Link` headers. For commits with more than 100 changed files, the callback only saw the first page.

This caused the `dox_graphql_publish_changes` workflow to **silently skip** publishing the doximity subgraph schema when [HG-601](https://github.com/doximity/doximity/pull/49569) merged with 228 changed files — the SDL file `config/graphql/federation_subgraph_schema.gql` was at position >100 and was never detected.

* commit that removed something in the `doximity` subgraph https://github.com/doximity/doximity/commit/3ee07aa55a13ed3de7900cf58238625d63025381
* the action run that did not detect the graphql subgraph schema change https://github.com/doximity/doximity/actions/runs/29273635017/job/86897188474

## Root Cause

`src/strategies/ref.js:fetchPayload()` called `GET /repos/{repo}/commits/{ref}?per_page=100` with no pagination. Same issue in `src/strategies/pull_request.js`.

## Fix

- Add `getPaginated()` method to `GithubApiClient` that follows `Link: <url>; rel="next"` headers
- `RefStrategy` merges `.files` across all commit pages
- `PullRequestStrategy` flattens across all PR file pages
- Add unit tests for pagination behavior (multi-page merge, single page, no Link header)
- Bump version to 1.1.0
- Update `action.yml` from `node16` to `node24` (node16 is deprecated)

After merging, consumers referencing `@v1` or `@v1.0.1` should update to `@v1.1.0`.

## Testing

```
✓ 12 tests passed
✓ eslint clean
✓ dist rebuilt
```

[CSVUEAN-3043]: https://doximity.atlassian.net/browse/CSVUEAN-3043?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[HG-601]: https://doximity.atlassian.net/browse/HG-601?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ